### PR TITLE
Dispose of AnimationController in lifecycle method

### DIFF
--- a/lib/views/new_game.dart
+++ b/lib/views/new_game.dart
@@ -29,6 +29,12 @@ class _NewGameState extends State<NewGame> with SingleTickerProviderStateMixin {
   Uuid uuid = Uuid();
 
   @override
+  dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
     _awayTeamController = TextEditingController();


### PR DESCRIPTION
There was an error when transitioning from the new_game screen to the score_game
screen. It was due to an `AnimationController` not being garbage collected properly.

This PR will override the dispose method on new_game and call _animationController.dispose.